### PR TITLE
fix: build package before creating tarball in publish workflow

### DIFF
--- a/.changeset/fix-publish-build.md
+++ b/.changeset/fix-publish-build.md
@@ -1,0 +1,5 @@
+---
+"node-es-transformer": patch
+---
+
+Fix publish workflow to build package before creating tarball

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -91,6 +91,9 @@ jobs:
       - name: Install dependencies
         run: yarn install --frozen-lockfile
 
+      - name: Build
+        run: yarn build
+
       - name: Build tarball
         run: npm pack --silent
 


### PR DESCRIPTION
Fixes publish workflow by adding build step before npm pack to ensure dist/ files are included in the published package.