### PR TITLE
fix: restore release automation and use GitHub App token in publish workflow

### DIFF
--- a/.changeset/use-github-app-token-release-pr.md
+++ b/.changeset/use-github-app-token-release-pr.md
@@ -1,0 +1,5 @@
+---
+"node-es-transformer": patch
+---
+
+Use GitHub App token for release PRs and restore automatic GitHub and npm publishing after merge

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -37,9 +37,17 @@ jobs:
           echo "CI workflow did not succeed. Skipping release."
           exit 1
 
+      - name: Generate GitHub App Token
+        id: app-token
+        uses: actions/create-github-app-token@v1
+        with:
+          app-id: ${{ vars.APP_ID }}
+          private-key: ${{ secrets.APP_PRIVATE_KEY }}
+
       - name: Checkout
         uses: actions/checkout@v6
         with:
+          token: ${{ steps.app-token.outputs.token }}
           fetch-depth: 0
 
       - name: Setup Node.js 22.x
@@ -69,8 +77,42 @@ jobs:
         if: steps.check-changesets.outputs.hasChangesets == 'true'
         run: node scripts/create-release-pr.mjs
         env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GITHUB_TOKEN: ${{ steps.app-token.outputs.token }}
           GITHUB_REPOSITORY: ${{ github.repository }}
+
+      - name: Check for Published Version
+        id: check-publish
+        if: steps.check-changesets.outputs.hasChangesets == 'false'
+        run: |
+          VERSION=$(node -p "require('./package.json').version")
+
+          if git ls-remote --tags origin "refs/tags/v${VERSION}" | grep -q "v${VERSION}$"; then
+            echo "shouldPublish=false" >> $GITHUB_OUTPUT
+            echo "Tag v${VERSION} already exists"
+          else
+            echo "shouldPublish=true" >> $GITHUB_OUTPUT
+            echo "version=${VERSION}" >> $GITHUB_OUTPUT
+            echo "Will create release for v${VERSION}"
+          fi
+
+      - name: Create GitHub Release
+        if: steps.check-publish.outputs.shouldPublish == 'true'
+        run: |
+          VERSION="${{ steps.check-publish.outputs.version }}"
+
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+
+          git tag -a "v${VERSION}" -m "Release v${VERSION}"
+          git push origin "v${VERSION}"
+
+          RELEASE_NOTES=$(awk '/^## / {if (found) exit; found=1; next} found' CHANGELOG.md)
+
+          gh release create "v${VERSION}" \
+            --title "v${VERSION}" \
+            --notes "${RELEASE_NOTES}"
+        env:
+          GH_TOKEN: ${{ steps.app-token.outputs.token }}
 
   build:
     name: Build package


### PR DESCRIPTION
Restore end-to-end release automation in publish.yml.

- Use GitHub App token for release PR creation so CI runs on release PRs
- Restore automatic tag and GitHub release creation after release PR merge when no changesets remain
- Keep npm publish triggered from release event

Includes a changeset entry for this workflow fix.